### PR TITLE
Remove -mmacosx-version-min=10.1

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -45,9 +45,6 @@ else ifeq ($(platform), osx)
    LDFLAGS += -dynamiclib
    
    fpic = -fPIC
-	OSXVER = `sw_vers -productVersion | cut -d. -f 2`
-	OSX_LT_MAVERICKS = `(( $(OSXVER) <= 9)) && echo "YES"`
-	fpic += -mmacosx-version-min=10.1
 ifndef ($(UNIVERSAL))
 	CFLAGS += $(ARCHFLAGS)
 	CXXFLAGS += $(ARCHFLAGS)


### PR DESCRIPTION
Recent Xcode doesn't allow c++ compilation with min version below 10.7.
Just leave it at default and user can still add it to ARCHFLAGS