### PR TITLE
[WiiU] Aroma CFW Compatibility

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -224,6 +224,7 @@ else ifeq ($(platform), wiiu)
    CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
    AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
    COMMONFLAGS += -DGEKKO -DWIIU -mrvl -mcpu=750 -meabi -mhard-float -D__POWERPC__
+   COMMONFLAGS += -ffunction-sections -fdata-sections -D__wiiu__ -D__wut__
    COMMONFLAGS += -DHAVE_SCANDIR=0 -DHAVE_ALPHASORT=0 -DHAVE_SIGACTION 
    STATIC_LINKING = 1
 else


### PR DESCRIPTION
This update will make the Core compatible with the soon to be released Aroma Retroarch port.
This should also be Tiramisu safe too so should be good to merge :)